### PR TITLE
Add command line support for exe patching  

### DIFF
--- a/Common/QDebug.cpp
+++ b/Common/QDebug.cpp
@@ -120,3 +120,12 @@ BOOL _cdecl QDebugWriteEntryFn(LPCSTR lpszFormat, va_list params)
 
 	return WriteFile(g_hLogFile, szLogBuffer, dwStringOffset, &dwBytesWritten, NULL);
 }
+
+void WINAPIV QDebugOut(const TCHAR* fmt, ...) {
+	TCHAR s[1025];
+	va_list args;
+	va_start(args, fmt);
+	wvsprintf(s, fmt, args);
+	va_end(args);
+	OutputDebugString(strcat(s, "\n"));
+}

--- a/Common/QDebug.h
+++ b/Common/QDebug.h
@@ -20,6 +20,8 @@ BOOL WINAPI QDebugCloseDeleteLogFileFn();
 
 BOOL _cdecl QDebugWriteEntryFn(LPCSTR lpszFormat, va_list params);
 
+void WINAPIV QDebugOut(const TCHAR* fmt, ...);
+
 /*
 	* QDebugWriteEntry *
 	Writes a log entry to the currently open log. Entry will be on a line of its own, and will have a time and date stamp. Log entries use sprintf, so any sprintf format specification is valid. Function fails if a log file is not open, but does not assert.

--- a/MPQDraft/MPQDraft.cpp
+++ b/MPQDraft/MPQDraft.cpp
@@ -194,7 +194,7 @@ BOOL CMPQDraft::InitConsole()
 	m_cmdParser.GetParams(params);
 	m_cmdParser.GetSwitches(switches);
 	if (switches.GetCount() < 1 || params.GetCount() < 3) {
-		QDebugOut("Usage: mpqdraft.exe -launch <scExePath> <mpqFiles> <qdpFiles>");
+		QDebugOut("Usage: MPQDraft.exe -launch <scExePath> <mpqFiles> <qdpFiles>");
 		return FALSE;
 	}
 

--- a/MPQDraft/MPQDraft.h
+++ b/MPQDraft/MPQDraft.h
@@ -21,6 +21,7 @@
 #endif
 
 #include "Common.h"
+#include "MPQDraftCommandParser.h"
 
 // A couple of functions to derive hash keys from CStrings. No idea why these 
 // functions aren't built into MFC.
@@ -103,6 +104,8 @@ public:
 		return index;
 	}
 
+	void ParseCommandLineArguments(CStringArray& params,CStringArray& switches);
+
 	// Gets the initial startup directory
 	inline const CString &GetStartupPath()
 	{ return m_strStartupPath; }
@@ -120,6 +123,9 @@ public:
 
 // Implementation
 protected:
+	virtual BOOL InitUI();
+	virtual BOOL InitConsole();
+
 	// Maps an icon's resource ID to its index in the icon image list
 	typedef CMap<DWORD, DWORD, int, int> TIconIdMap;
 
@@ -150,6 +156,9 @@ protected:
 		// NOTE - the ClassWizard will add and remove member functions here.
 		//    DO NOT EDIT what you see in these blocks of generated code !
 	//}}AFX_MSG
+private:
+	MPQDraftCommandParser m_cmdParser;
+
 	DECLARE_MESSAGE_MAP()
 };
 

--- a/MPQDraft/MPQDraft.vcxproj
+++ b/MPQDraft/MPQDraft.vcxproj
@@ -49,6 +49,7 @@
     <OutDir>.\Debug\</OutDir>
     <IntDir>.\Debug\</IntDir>
     <LinkIncremental>true</LinkIncremental>
+    <TargetName>$(ProjectName)D</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>.\Release\</OutDir>

--- a/MPQDraft/MPQDraft.vcxproj
+++ b/MPQDraft/MPQDraft.vcxproj
@@ -152,6 +152,7 @@
     <ClCompile Include="dibpal.cpp" />
     <ClCompile Include="MainMenu.cpp" />
     <ClCompile Include="MPQDraft.cpp" />
+    <ClCompile Include="MPQDraftCommandParser.cpp" />
     <ClCompile Include="patchwizard.cpp" />
     <ClCompile Include="ProgressWnd.cpp" />
     <ClCompile Include="SEMPQWizard.cpp" />
@@ -168,6 +169,7 @@
     <ClInclude Include="dibpal.h" />
     <ClInclude Include="MainMenu.h" />
     <ClInclude Include="MPQDraft.h" />
+    <ClInclude Include="MPQDraftCommandParser.h" />
     <ClInclude Include="patchwizard.h" />
     <ClInclude Include="ProgressWnd.h" />
     <ClInclude Include="resource.h" />

--- a/MPQDraft/MPQDraft.vcxproj.filters
+++ b/MPQDraft/MPQDraft.vcxproj.filters
@@ -57,6 +57,9 @@
     <ClCompile Include="StdAfx.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="MPQDraftCommandParser.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="BitmapDialog.h">
@@ -102,6 +105,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="StdAfx.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="MPQDraftCommandParser.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/MPQDraft/MPQDraftCommandParser.cpp
+++ b/MPQDraft/MPQDraftCommandParser.cpp
@@ -1,0 +1,33 @@
+#include "MPQDraftCommandParser.h"
+
+void MPQDraftCommandParser::ParseParam(const TCHAR* param, BOOL isFlag, BOOL isLast)
+{
+	CString param_or_switch(param);
+	if (isFlag) {
+		m_switches.Add(param_or_switch);
+	}
+	else {
+		m_params.Add(param_or_switch);
+	}
+}
+
+MPQDraftCommandParser::MPQDraftCommandParser(void)
+{
+}
+
+MPQDraftCommandParser::~MPQDraftCommandParser(void)
+{
+}
+
+void MPQDraftCommandParser::GetParams(CStringArray& params)
+{
+	int size = m_params.GetCount();
+	for (int i = 0; i < size; i++)
+		params.Add(m_params.GetAt(i));
+}
+void MPQDraftCommandParser::GetSwitches(CStringArray& switches)
+{
+	int size = m_switches.GetCount();
+	for (int i = 0; i < size; i++)
+		switches.Add(m_switches.GetAt(i));
+}

--- a/MPQDraft/MPQDraftCommandParser.h
+++ b/MPQDraft/MPQDraftCommandParser.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <afxwin.h>
+class MPQDraftCommandParser : public CCommandLineInfo
+{
+public:
+	MPQDraftCommandParser(void);
+	virtual ~MPQDraftCommandParser(void);
+	void GetParams(CStringArray& params);
+	void GetSwitches(CStringArray& switches);
+private:
+	CStringArray m_params;
+	CStringArray m_switches;
+	void ParseParam(const TCHAR* param, BOOL isFlag, BOOL isLast);
+};

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 MPQDraft allows in-memory patching of game data files, added features through plugins, and creation of self-executing mods.
 This fork aims to update MPQDraft up to Win10 APIs and streamline the development process when used in combination with GPTP plugin development.
 
+## Command Line Usage
+```
+Usage: MPQDraft.exe -launch <scExePath> <mpqFiles> <qdpFiles>
+
+Example:
+MPQDraft.exe -launch "C:\Starcraft\StarCraft.exe" "C:\Mod\my_mod_1.mpq,C:\Mod\my_mod_2.mpq" "C:Mod\my_plugin_1.qdp,C:\Mod\my_plugin_2.qdp"
+```
 
 ## Development
 Required Visual Studio components:
@@ -16,5 +23,4 @@ Required Visual Studio components:
 - Open Debug\MPQDraftD.exe
 
 ## Credits
-[Quantam, creator of MPQDraft](http://qstuff.blogspot.com/2010/01/bibliography-programming.html)
-Licensed under CDDL 
+[Quantam, creator of MPQDraft](http://qstuff.blogspot.com/2010/01/bibliography-programming.html) Licensed under CDDL 


### PR DESCRIPTION
Add support for exe patching through command line by extracting relevant functionality from the UI
`Usage: MPQDraft.exe -launch <scExePath> <mpqFiles> <qdpFiles>`

```Example:
MPQDraft.exe -launch "C:\Starcraft\StarCraft.exe" "C:\Mod\my_mod_1.mpq,C:\Mod\my_mod_2.mpq" "C:Mod\my_plugin_1.qdp,C:\Mod\my_plugin_2.qdp"```